### PR TITLE
Remove custom config to accept 2 trailing spaces for mdl

### DIFF
--- a/.github/workflows/mdl_style.rb
+++ b/.github/workflows/mdl_style.rb
@@ -3,6 +3,3 @@ all
 
 # Exclude the rules that refers to the line length
 exclude_tag :line_length
-
-# Set accepted trailing spaces to a maximum of 2 (used to break a line) for the MD009 rule
-rule 'MD009', :br_spaces => 2


### PR DESCRIPTION
https://github.com/markdownlint/markdownlint/pull/452